### PR TITLE
Added PropTypes to Button.ios.js to match Button.android.js and work with the new version of React

### DIFF
--- a/Button.ios.js
+++ b/Button.ios.js
@@ -1,4 +1,6 @@
 import React,{Component} from 'react'
+import PropTypes from 'prop-types'
+
 import {
   TouchableOpacity,
   View,
@@ -14,6 +16,6 @@ class Button extends Component{
   }
 }
 Button.propTypes = {
-  children: React.PropTypes.any.isRequired,
+  children: PropTypes.any.isRequired,
 }
 export default Button;


### PR DESCRIPTION
This PR adds PropTypes to Button.ios.js to prevent errors when this library is used with the newer versions of React which doesn't have PropTypes.